### PR TITLE
Fix duplicate `OOBCallbackRequestDTO`, `UploadRfiDocumentRequestDTO`, `UploadRfiDetailsResponseDTO`

### DIFF
--- a/nium.yaml
+++ b/nium.yaml
@@ -4625,7 +4625,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UploadRfiDetailsResponseDto'
+                $ref: '#/components/schemas/UploadRfiDetailsResponseDTO'
               example:
                 complianceId: c36061eb-7b83-48c2-9977-bb144b10aad9
                 status: RFI_RESPONDED
@@ -23232,28 +23232,6 @@ components:
           example: Customer Updated Successfull
           type: string
       title: Update customer response
-      type: object
-    UploadRfiDetailsResponseDto:
-      properties:
-        complianceId:
-          description: This field contains the unique compliance ID for the customer.
-          format: uuid
-          type: string
-        rfiId:
-          description: 'This field contains the unique RFI ID. This is for future
-            use.
-
-            Currently, the value shall be null.'
-          format: uuid
-          type: string
-        status:
-          description: "This field contains the status and following are the valid\
-            \ values for compliance status:\n\u2022 IN_PROGRESS\n\u2022 ACTION_REQUIRED\n\
-            \u2022 RFI_REQUESTED\n\u2022 RFI_RESPONDED\n\u2022 COMPLETED\n\u2022 REJECT\n\
-            \u2022 ERROR\nIn case of successful response to RFI, expected status is\
-            \ RFI_RESPONDED."
-          type: string
-      title: Upload Rfi details response
       type: object
     AddCategoryResponseDTO:
       properties:

--- a/nium.yaml
+++ b/nium.yaml
@@ -2358,7 +2358,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OobCallbackRequestDTO'
+              $ref: '#/components/schemas/OOBCallbackRequestDTO'
         required: true
         description: oobCallbackRequestDTO
       responses:
@@ -4672,7 +4672,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UploadRfiDocumentRequestDto'
+              $ref: '#/components/schemas/UploadRfiDocumentRequestDTO'
             example:
               rfiResponseRequest:
               - rfiHashId: e908b61e-f057-44c6-a352-3a8a2cb73bac
@@ -15994,32 +15994,6 @@ components:
             request.
           example: Card Activated successfully
       title: ActivateCardResponseV2DTO
-    OobCallbackRequestDTO:
-      required:
-      - authTransactionId
-      - referenceNumber
-      - statusCode
-      type: object
-      properties:
-        authTransactionId:
-          type: string
-          description: This field represents the unique authorization ID of the transaction
-            received during the OOB authentication.
-        referenceNumber:
-          type: string
-          description: A reference number is a unique ID associated with the OOB request
-            from your system.
-        statusCode:
-          type: string
-          description: "The OOB authentication status code indicated if the transaction\
-            \ is approved or declined. The allowed values are: 001 \u2014 OOB authentication\
-            \ approved, 002 \u2014 OOB authentication declined."
-          enum:
-          - 001, 002
-        message:
-          type: string
-          description: An optional field to attach a message associated with the authentication.
-      title: OobCallbackRequestDTO
     BlockAndReplaceStatus:
       type: object
       properties:
@@ -23280,18 +23254,6 @@ components:
             \ RFI_RESPONDED."
           type: string
       title: Upload Rfi details response
-      type: object
-    UploadRfiDocumentRequestDto:
-      properties:
-        rfiResponseRequest:
-          description: This field accepts the additional requests for information,
-            depending upon documents required to raise RFI
-          items:
-            $ref: '#/components/schemas/RfiResponseRequest'
-          type: array
-      required:
-      - rfiResponseRequest
-      title: Upload Rfi document request
       type: object
     AddCategoryResponseDTO:
       properties:


### PR DESCRIPTION
After generating Go implementation using openapi-generator cli, the code is unable to compile

```
pack/http/sdk/nium/api_class3_ds.go:264:25: undefined: OOBCallbackRequestDTO
pack/http/sdk/nium/api_class3_ds.go:269:83: undefined: OOBCallbackRequestDTO
pack/http/sdk/nium/api_payout.go:138:72: undefined: UploadRfiDetailsResponseDTO
pack/http/sdk/nium/api_payout.go:1415:31: undefined: UploadRfiDocumentRequestDTO
pack/http/sdk/nium/api_payout.go:1420:100: undefined: UploadRfiDocumentRequestDTO
pack/http/sdk/nium/api_payout.go:1431:56: undefined: UploadRfiDetailsResponseDTO
pack/http/sdk/nium/api_payout.go:1460:98: undefined: UploadRfiDetailsResponseDTO
pack/http/sdk/nium/api_payout.go:1465:25: undefined: UploadRfiDetailsResponseDTO
```